### PR TITLE
Added option to output top queries to CSV format, for follow-up analysis...

### DIFF
--- a/README
+++ b/README
@@ -130,6 +130,11 @@ SYNOPSIS
                                  mode.
         --log-duration         : force pgbadger to associate log entries generated
                                  by both log_duration = on and log_statement = 'all'
+        --csv-output           : For the Top Queries section, also output the
+                                 results in csv format, for example, to COPY into
+                                 a PostgreSQL database for analysis.
+        --csv-filename filename: The filename to emit the Top Queries to.
+                                 Defaults to topqueries.csv.
 
     pgBadger is able to parse a remote log file using a passwordless ssh
     connection. Use the -r or --remote-host to set the host ip address or

--- a/pgbadger
+++ b/pgbadger
@@ -236,6 +236,9 @@ my $nomultiline             = 0;
 my $noreport                = 0;
 my $log_duration            = 0;
 my $logfile_list            = '';
+my $csv_output              = 0;
+my $csv_filename            = '';
+my $csv                     = '';
 
 my $NUMPROGRESS = 10000;
 my @DIMENSIONS  = (800, 300);
@@ -384,6 +387,8 @@ my $result = GetOptions(
 	'noclean!'                 => \$noclean,
 	'noreport!'                => \$noreport,
 	'log-duration!'            => \$log_duration,
+	"csv-output!"              => \$csv_output,
+	"csv-filename=s"           => \$csv_filename,
 );
 die "FATAL: use pgbadger --help\n" if (not $result);
 
@@ -531,6 +536,9 @@ if ($format eq 'syslog2') {
 # Set default top query
 $top ||= 20;
 
+# Set default top queries csv_filename
+$csv_filename ||= 'topqueries.csv';
+
 # Set the default extension and output format
 if (!$extension) {
 	if ($outfile =~ /\.bin/i) {
@@ -562,6 +570,14 @@ if (!$extension) {
 # Set default filename of the output file
 $outfile ||= 'out.' . $extension;
 &logmsg('DEBUG', "Output '$extension' reports will be written to $outfile");
+
+if ($csv_output) {
+	if (eval {require Text::CSV;1;} ne 1) {
+		die("Can not save output in csv format, please install Perl module Text::CSV first.\n");
+	} else {
+		Text::CSV->import();
+	}
+}
 
 # Set default syslog ident name
 $ident ||= 'postgres';
@@ -1322,6 +1338,7 @@ my $td = timediff($t1, $t0);
 
 # Global output filehandle
 my $fh = undef;
+my $fhcsv = undef;
 
 if (!$incremental && ($#given_log_files >= 0) ) {
 
@@ -3413,16 +3430,38 @@ Report not supported by text format
 		print $fh "\n- Queries that took up the most time (N) -------------------------------\n\n";
 		print $fh "Rank     Total duration      Times executed     Min/Max/Avg duration (s)     Query\n";
 		my $idx = 1;
+
+		# XXX: CSV output for top queries
+		if ( $csv_output ) {
+			my @column_names = qw(Rank Total_Duration Times_Executed Min Max Avg Query);
+			$csv = Text::CSV->new({
+					 binary => 1,      # should set binary attribute.
+					 eol    => $/,     # end of line character
+				}) or die "Cannot use CSV: ".Text::CSV->error_diag ();
+			open $fhcsv, ">", "$csv_filename" or die "newq.csv: $!";
+			$csv->print($fhcsv, ['Database','Rank','Total_Duration','Times_Executed','Min','Max','Avg','Query']);
+		}
+
 		foreach my $k (sort {$normalyzed_info{$b}{duration} <=> $normalyzed_info{$a}{duration}} keys %normalyzed_info) {
 			next if (!$normalyzed_info{$k}{count});
 			last if ($idx > $top);
 			my $q = $k;
+			my $dbname = '';
+
 			if ($normalyzed_info{$k}{count} == 1) {
 				foreach (keys %{$normalyzed_info{$k}{samples}}) {
 					$q = $normalyzed_info{$k}{samples}{$_}{query};
 					last;
 				}
 			}
+
+			foreach (keys %{$normalyzed_info{$k}{samples}}) {
+				if ( $dbname eq '' ) {
+					$dbname = $normalyzed_info{$k}{samples}{$_}{db};
+				}
+				last;
+			}
+
 			$normalyzed_info{$k}{average} = $normalyzed_info{$k}{duration} / $normalyzed_info{$k}{count};
 			print $fh "$idx) "
 				. &convert_time($normalyzed_info{$k}{duration}) . " - "
@@ -3432,6 +3471,20 @@ Report not supported by text format
 				. &convert_time($normalyzed_info{$k}{average})
 				. " - $q\n";
 			print $fh "--\n";
+
+			if ( $csv_output ) {
+				$csv->print ($fhcsv, [
+					"$dbname",
+					"$idx",
+					&convert_time($normalyzed_info{$k}{duration}),
+					$normalyzed_info{$k}{count},
+					&convert_time($normalyzed_info{$k}{min}),
+					&convert_time($normalyzed_info{$k}{max}),
+					&convert_time($normalyzed_info{$k}{average}),
+					"$q"
+				]);
+			}
+
 			my $i = 1;
 			foreach my $d (sort {$b <=> $a} keys %{$normalyzed_info{$k}{samples}}) {
 				my $db = " - database: $normalyzed_info{$k}{samples}{$d}{db}" if ($normalyzed_info{$k}{samples}{$d}{db});
@@ -3443,8 +3496,13 @@ Report not supported by text format
 				print $fh "\t- Example $i: ", &convert_time($d), "$db - ", $normalyzed_info{$k}{samples}{$d}{query}, "\n";
 				$i++;
 			}
+
 			$idx++;
 		}
+		if ( $csv_output ) {
+			close $fhcsv or die "$!";
+		}
+
 	}
 	if (!$disable_query && (scalar keys %normalyzed_info > 0)) {
 		print $fh "\n- Most frequent queries (N) --------------------------------------------\n\n";
@@ -7382,20 +7440,20 @@ sub print_time_consuming
 			$details .= " ]";
 			$query = &highlight_code($normalyzed_info{$k}{samples}{$d}{query});
 			print $fh qq{
-								<dt>
-								<div id="query-e-$rank-$idx" class="sql sql-largesize"><i class="icon-copy" title="Click to select query"></i>$query</div>
-								</dt>
-								<pre>$details</pre>
+                                        			<dt>
+                                        			<div id="query-e-$rank-$idx" class="sql sql-largesize"><i class="icon-copy" title="Click to select query"></i>$query</div>
+                                        			</dt>
+                                        			<pre>$details</pre>
 };
 			$idx++;
 		}
 		print $fh qq{
-							</dl>
-							<p class="pull-right"><button type="button" class="btn btn-mini" data-toggle="collapse" data-target="#time-consuming-queries-examples-rank-$rank">x Hide</button></p>
-						</div>
-						<!-- end of details collapse -->
-					</td>
-				</tr>
+                                            		</dl>
+                                            		<p class="pull-right"><button type="button" class="btn btn-mini" data-toggle="collapse" data-target="#time-consuming-queries-examples-rank-$rank">x Hide</button></p>
+                                                </div>
+                                                <!-- end of details collapse -->
+                                        </td>
+                                </tr>
 };
 		$rank++;
 	}


### PR DESCRIPTION
Currently only works for the top (normalized) queries.
Note: I would like to have made this a bit more full-featured, for example, by adding more switches to output only top-normalized-queries, slowest-queries, most-time-consuming-queries etc, but I have run out of time for now.