### PR TITLE
Sort %SYMBOLS hashtable to remove "!=" / "=" bug.

### DIFF
--- a/pgbadger
+++ b/pgbadger
@@ -10020,7 +10020,7 @@ sub highlight_code
 		$i++;
 	}
 
-	foreach my $x (keys %SYMBOLS) {
+	foreach my $x (sort (keys %SYMBOLS)) {
 		$code =~ s/$x/\$\$PGBGYA\$\$$SYMBOLS{$x}\$\$PGBGYB\$\$/gs;
 	}
 	for (my $x = 0 ; $x <= $#KEYWORDS1 ; $x++) {


### PR DESCRIPTION
When using the "! =" in queries a random bug appears.
This error is due to order of items in "% SYMBOLS" hashtable is  random.
A quick fix is sorting %SYMBOLS  :) : != is before =.

How to reproduce:
Use the following log file:
Feb 10 14:55:24 postgres postgres[23121]: [135-1] [23121]: [125-1] user=bugfix,db=bugfix,app=[unknown],client=10.1.1.1 LOG:  duration: 0.080 ms  execute <unnamed>: SELECT * FROM SOMEBASE WHERE BUG='DEMO' AND TYPE!='DEMO'

Run : pgbadger -f syslog sample.log

In generated report you can see : 
SELECT * FROM SOMEBASE WHERE BUG = 'DEMO' AND TYPE $$PGBGYA$$!=$$PGBGYB$$ 'DEMO'; 

In HTML source : 
`
<i class="icon-copy" title="Click to select query"></i>
<span class="kw1">SELECT</span>
<span class="sy0">*</span>
<span class="kw1">FROM</span>
SOMEBASE
<span class="kw1">WHERE</span>
BUG
<span class="sy0">=</span>
<span class="st0">'DEMO'</span>
<span class="kw1">AND</span>
<span class="kw1">TYPE</span>
$$PGBGYA$$!
<span class="sy0">=</span>
$$PGBGYB$$
<span class="st0">'DEMO'</span>
;
</div>
`