### PR TITLE
Add link to apt.postgresql.org and fix a typo in the yum section

### DIFF
--- a/index.html
+++ b/index.html
@@ -2078,7 +2078,11 @@ Not all release are subject to a notification sent to the pgsql-announce maillin
 		<h2><i class="icon-sitemap"></i> Binary packages</h2>
 		<div class="span8">
 <p>
-pgBadger may have a binary package corresponding to your distribution. For RPM packages, thanks to the great work of Devrim GÜNDÜZ, you can find the pgBadger package at the <a href="http://yum.postgresql.org/packages.php">PostgreQSL yum repository</a>
+pgBadger may have a binary package corresponding to your distribution. For RPM packages, thanks to the great work of Devrim GÜNDÜZ, you can find the pgBadger package at the <a href="http://yum.postgresql.org/packages.php">PostgreSQL yum repository</a>
+</p>
+
+<p>
+Packages for Debian and Ubuntu are available in the <a href="https://wiki.postgresql.org/wiki/Apt">PostgreSQL apt repository</a>.
 </p>
 
 <p>


### PR DESCRIPTION
Debian unstable and apt.postgresql.org have up-to-date pgBadger packages
now.