### PR TITLE
Fix reading from stdin by disabling pgbouncer file format detection

### DIFF
--- a/pgbadger
+++ b/pgbadger
@@ -2282,8 +2282,11 @@ sub process_file
 		&logmsg('DEBUG', "Starting reading file $remote_host:$logfile...");
 	}
 
-	# Detect if we are parsing a pgbouncer file
-	my ($is_pgbouncer_format, $retcode, $msg) = &detect_pgbouncer_log($logfile, $saved_last_line{datetime}, 1);
+	my $is_pgbouncer_format = 0;
+	if ($logfile ne '-') {
+		# Detect if we are parsing a pgbouncer file
+		my ($is_pgbouncer_format, $retcode, $msg) = &detect_pgbouncer_log($logfile, $saved_last_line{datetime}, 1);
+	}
 
 	# Parse pgbouncer logfile
 	if ($is_pgbouncer_format) {


### PR DESCRIPTION
When passing log content to pgbadger via stdin, it is at the moment unable to read the data.

How to reproduce:
```
cat logfile | pgbadger -O /somewhere/output -
```
Creates the same output disregarding file content of logfile (even when logfile is empty).

This hotfix disables pgbouncer logfile format detection and enables pgbadger to process the data from stdin once again. Reading files in pgbouncer format from stdin would probably need an extra command-line option.