### PR TITLE
Drop --bar-graph option

### DIFF
--- a/README
+++ b/README
@@ -19,7 +19,6 @@ SYNOPSIS
         -A | --histo-average N : number of minutes to build the histogram graphs
                                  of queries. Default 60 minutes.
         -b | --begin datetime  : start date/time for the data to be parsed in log.
-        -B | --bar-graph       : use bar graph instead of line by default.
         -c | --dbclient host   : only report on entries for the given client host.
         -C | --nocomment       : remove comments like /* ... */ from queries.
         -d | --dbname database : only report on entries for the given database.

--- a/pgbadger
+++ b/pgbadger
@@ -312,7 +312,6 @@ my $last_incr_date          = '';
 my $anonymize               = 0;
 my $noclean                 = 0;
 my $retention               = 0;
-my $bar_graph               = 0;
 my $dns_resolv              = 0;
 my $nomultiline             = 0;
 my $noreport                = 0;
@@ -407,7 +406,6 @@ my $result = GetOptions(
 	"a|average=i"              => \$avg_minutes,
 	"A|histo-average=i"        => \$histo_avg_minutes,
 	"b|begin=s"                => \$from,
-	"B|bar-graph!"             => \$bar_graph,
 	"c|dbclient=s"             => \@dbclient,
 	"C|nocomment!"             => \$remove_comment,
 	"d|dbname=s"               => \@dbname,
@@ -1755,7 +1753,6 @@ Options:
     -A | --histo-average min: number of minutes to build the histogram graphs
                              of queries. Default 60 minutes.
     -b | --begin datetime  : start date/time for the data to be parsed in log.
-    -B | --bar-graph       : use bar graph instead of line by default.
     -c | --dbclient host   : only report on entries for the given client host.
     -C | --nocomment       : remove comments like /* ... */ from queries.
     -d | --dbname database : only report on entries for the given database.


### PR DESCRIPTION
Closes: #351 

This patch drops `-B` option from CLI parser, inline help and documentation as proposed in #351 

I don't find the actual code using `bar_graph`. Looks like it is already dropped. Please confirm this !

cc @darold @jpargudo 