### PR TITLE
Add editorconfig configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = tab
+indent_size = 8
+# Unix-style newlines
+end_of_line = lf
+# Remove any whitespace characters preceding newline characters
+trim_trailing_whitespace = true
+# Newline ending every file
+insert_final_newline = true
+
+[*.yml]
+indent_style = space
+indent_size = 2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,3 +7,9 @@
 2. Look at the [closed issues](https://github.com/dalibo/pgbadger/issues?state=closed), we may have already answered a similar problem
 
 3. [Read the doc](http://dalibo.github.com/pgbadger/). It is short and useful.
+
+
+## Coding style
+
+pgBadger project provides a [.editorconfig](http://editorconfig.org/) file to
+setup consistent spacing in files. Please follow it!


### PR DESCRIPTION
Reading pgBadger I found a lot of mixed tabs and spaces, trailing spaces, etc. Here is a `.editorconfig` to help keeping spacing sane.