### PR TITLE
doc update : stderr is not a default for -f

### DIFF
--- a/README
+++ b/README
@@ -27,7 +27,7 @@ SYNOPSIS
         -e | --end datetime    : end date/time for the data to be parsed in log.
         -f | --format logtype  : possible values: syslog, syslog2, stderr, csv and
                                  pgbouncer. Use this option when pgBadger is not
-                                 able to auto-detect the log format Default: stderr.
+                                 able to auto-detect the log format.
         -G | --nograph         : disable graphs on HTML output. Enabled by default.
         -h | --help            : show this message and exit.
         -i | --ident name      : programname used as syslog ident. Default: postgres
@@ -250,10 +250,11 @@ DESCRIPTION
     embedded.
 
     pgBadger is able to autodetect your log file format (syslog, stderr or
-    csvlog). It is designed to parse huge log files as well as gzip
-    compressed files. See a complete list of features below. Supported
-    compressed format are gzip, bzip2 and xz. For the xz format you must
-    have an xz version upper than 5.05 that supports the --robot option.
+    csvlog) if the log file is long enough. It is designed to parse huge log
+    files as well as gzip compressed files. See a complete list of features
+    below. Supported compressed format are gzip, bzip2 and xz. For the xz
+    format you must have an xz version upper than 5.05 that supports the
+    --robot option.
 
     All charts are zoomable and can be saved as PNG images.
 

--- a/doc/pgBadger.pod
+++ b/doc/pgBadger.pod
@@ -29,7 +29,7 @@ Options:
     -e | --end datetime    : end date/time for the data to be parsed in log.
     -f | --format logtype  : possible values: syslog, syslog2, stderr, csv and
 			     pgbouncer. Use this option when pgBadger is not
-                             able to auto-detect the log format Default: stderr.
+                             able to auto-detect the log format.
     -G | --nograph         : disable graphs on HTML output. Enabled by default.
     -h | --help            : show this message and exit.
     -i | --ident name      : programname used as syslog ident. Default: postgres
@@ -250,7 +250,8 @@ other packages. Furthermore, this library gives us more features such
 as zooming. pgBadger also uses the Bootstrap JavaScript library and
 the FontAwesome webfont for better design. Everything is embedded.
 
-pgBadger is able to autodetect your log file format (syslog, stderr or csvlog).
+pgBadger is able to autodetect your log file format (syslog, stderr or csvlog)
+if the log file is long enough.
 It is designed to parse huge log files as well as gzip compressed files. See a
 complete list of features below. Supported compressed format are gzip, bzip2
 and xz. For the xz format you must have an xz version upper than 5.05 that

--- a/pgbadger
+++ b/pgbadger
@@ -1776,7 +1776,7 @@ Options:
     -e | --end datetime    : end date/time for the data to be parsed in log.
     -f | --format logtype  : possible values: syslog, syslog2, stderr, csv and
 			     pgbouncer. Use this option when pgBadger is not
-                             able to auto-detect the log format Default: stderr.
+                             able to auto-detect the log format.
     -G | --nograph         : disable graphs on HTML output. Enabled by default.
     -h | --help            : show this message and exit.
     -i | --ident name      : programname used as syslog ident. Default: postgres


### PR DESCRIPTION
"stderr" is not a default for -f , as when autodetection fails, there is no fallback to stderr

We had the problem with a customer whose log was too small. Adding -f stderr explicitely solved the problem.

I've discussed this with Gilles: he did change the behaviour. pgbadger needs 10 lines  (see line 13879).