### PR TITLE
Change --pid-file to --pid-dir in README

### DIFF
--- a/README
+++ b/README
@@ -137,7 +137,7 @@ SYNOPSIS
         --journalctl command   : command to use to replace PostgreSQL logfile by
                                  a call to journalctl. Basically it might be:
                                     journalctl -u postgresql-9.5
-        --pid-file PATH        : set the path of the pid file to manage
+        --pid-dir PATH         : set the path of the pid file to manage
                                  concurrent execution of pgBadger.
         --rebuild              : used to rebuild all html reports in incremental
                                  output directories where there is binary data files.

--- a/doc/pgBadger.pod
+++ b/doc/pgBadger.pod
@@ -139,7 +139,7 @@ Options:
     --journalctl command   : command to use to replace PostgreSQL logfile by
 			     a call to journalctl. Basically it might be:
 				journalctl -u postgresql-9.5
-    --pid-file PATH        : set the path of the pid file to manage
+    --pid-dir PATH         : set the path of the pid file to manage
 			     concurrent execution of pgBadger.
     --rebuild              : used to rebuild all html reports in incremental
                              output directories where there is binary data files.


### PR DESCRIPTION
It irritated me that --pid-file was still in the readme of this site while in the program the option is called --pid-dir. I changed it to prevent others from running into this mistake :)